### PR TITLE
Update Types of Ventilators.md

### DIFF
--- a/4. Pulmonary Mechanical Ventilation/08. Types of Ventilators/Types of Ventilators.md
+++ b/4. Pulmonary Mechanical Ventilation/08. Types of Ventilators/Types of Ventilators.md
@@ -1,29 +1,61 @@
-# Types of Mechanical Ventilators
+# Types of Mechanical Ventilators [if this is what is to be discussed in this section, then modes should be moved elsewhere, but I've inserted content I think needs to be included in modes below)
 
-### Volume cycled
-* Preset volume of gas (tidal volume) is predetermined and delivered despite the amount of pressure generated
+Mechanical ventilation is indicated for patients with respiratory failure who are unable to maintain adequate gas exchange.
+Mechanical ventilators deliver positive pressure using a number of settings within a specified overall mode.
 
-### Pressure cycled
-* Gas pressure is predetermined
+# Mechanical Ventilator Settings 
+Mechanical ventilators can be programed to deliver a number of specific settings. Keep in mind that not all modes use all of the following settings.
+* FiO2: fraction of inspired oxygen (percentage of oxygen delivered)
+* RR/f: respiratory rate or frequency (number of breaths delivered per minute by the ventilator)
+* Vt: tidal volume (size of each breath)
+* PS: pressure support (amount of pressure delivered with each breath)
+* PEEP: Positive End Expiratory Pressure (additional positive pressure provided at the end of expiratio to keep alveoli open)
+* I:E ratio: Inspiratory/Expiratory ratio, or the duration of inhalation compared to exhalation
+
+
+# Models of Mechanical Ventilators
+
+
+
+The "mode" describes the ventilator's general relationship with the patient. Settings can vary within a mode. Modes can be pressure targetted or volume  targetted and the level of support can vary from mode to mode. In some modes, the ventilator does all of the work of breathing, while other modes can require the patient to do more work of breathing.
+
+### Volume Targetted
+* Preset volume of gas (tidal volume or "Vt") is predetermined and delivered despite the amount of pressure generated
+
+### Pressure Targetted
+* Preset pressure of gas delivery is predetermined
 * Gas flow to patient ceases when pressure reaches preset level
 * May mean that patient does not receive targeted
 tidal volume
 
-# Question 1
-What differentiates a Volume Cycled and Pressure Cycled Mechanical Ventilator?
+# Select modes (this list is not comprehensive)
+All of these modes will include a pre-set PEEP and FiO2, from there, the additional support may be provided depending on the mode
+* Assist Control (A/C) - A volume targetted mode
+Provides a predetermined set number of breaths (RR), each with a pre-set tidal volume (Vt). The patient may take additional breaths above the pre-set number (RR setting), and those additional breaths will be supported by the preset tidal volume as well.
 
-[RIGHT] Volume Cycled ventilators have a predetermined tidal volume, Pressure Cycled ventilators cease gas flow when pressure reaches the preset level
-[WRONG] Volume Cycled ventilators have a predetermined tidal volume, Pressure Cycled ventilators begin gas flow when pressure reaches the preset level
+* Synchronized Intermittent Mandatory Ventilation (SIMV) - A volume targetted mode
+Provides a predetermined set number of breaths (RR), each with a preset tidal volume (Vt). The patient may take additional breaths above the pre-set number (RR setting), however, those additional breaths will NOT be supported by the preset tidal volume- the volume of these breaths will be determined by patient effort
+
+* Pressure Support (PS) - A pressure targetted mode
+Provides a preset pressure when a patient "triggers" the ventilator (demonstrates inspiratory effort). There is NO pre-set respiratory rate or tidal volume. The patient will determine their own respiratory rate, but each effort to take a breath will be supported by a set pressure amount.
+
+
+
+# Question 1
+What differentiates Volume targetted and Pressure targetted modes of ventilation?
+
+[RIGHT] Volume targetted ventilation has a predetermined tidal volume, Pressure targetted modes cease gas flow when pressure reaches the preset level
+[WRONG] Pressure targetted ventilation has a predetermined tidal volume, Volume targetted modes begin gas flow when pressure reaches the preset level
 
 # Question 2
-A mechanical ventilator with a preset volume of gas that is delivered despite the amount of pressure generated is known as what?
+A ventilator mode with a preset volume of gas that is delivered despite the amount of pressure generated is known as what?
 
-[WRONG] Manual cycled
-[WRONG] Pressure cycled
-[RIGHT] Volume cycled
+[WRONG] Manual targetted
+[WRONG] Pressure targetted
+[RIGHT] Volume targetted
 
 
-# Models of Mechanical Ventilators
+Types of Ventilators (I don't know that I see value in the information below if this is truly a "Crash course" in mechanical ventilation...)
 
 ### PB 840 Ventilator
 ![](assets/pb840.png)
@@ -37,6 +69,7 @@ A mechanical ventilator with a preset volume of gas that is delivered despite th
 * External alarm and streaming capabilities
 
 ### PB980 Ventilator
+
 ![](assets/pb980.png)
 
 * Modes: A/C, SIMV, PS, Bilevel


### PR DESCRIPTION
I think the title of this section should just include types of ventilators-- the different brands/types of machines-- or just modes-- these shouldn't be in the same module to reduce confusion- I did, however, include mode information here so it can be placed wherever once the decision is made

One thought : I don't know how valuable it is to share all of the different ventilator models -- I doubt anyone would remember the differences between a Trilogy and a Phillips for example-- I couldn't even tell you the names of all of the model's I've worked with- the key is that the nurse can identify important information in any model. Nurses do not need to know which models can run which modes- this is purely a respiratory therapist knowledge base, not RN

Alarms should be discussed in a separate section as well

I deleted some content that is not within the nurse's responsibility--- the respiratory therapist is in charge of setting up the vent, not the RN-- the RN needs to understand how to manage the vent and what specific settings and modes mean, but other than that, this could be seen as very "content-overloaded" since many experienced ICU nurses don't understand what a lot of this means since it isn't in our scope of practice